### PR TITLE
Fixed extraction loop to enable the extraction of "directory only" zip f...

### DIFF
--- a/Unzip.cs
+++ b/Unzip.cs
@@ -130,15 +130,15 @@ namespace Internals
 		/// <param name="directoryName">Name of the directory.</param>
 		public void ExtractToDirectory(string directoryName)
 		{
-			foreach (var entry in Entries.Where(e => !e.IsDirectory))
+			foreach (var entry in Entries)
 			{
 				// create target directory for the file
 				var fileName = Path.Combine(directoryName, entry.Name);
 				var dirName = Path.GetDirectoryName(fileName);
 				Directory.CreateDirectory(dirName);
 
-				// save file
-				Extract(entry.Name, fileName);
+				// save file if it is not only a directory
+                if(!entry.IsDirectory) Extract(entry.Name, fileName);
 			}
 		}
 


### PR DESCRIPTION
...iles that are used to replicate empty (template) folder structures.

I know this "fix" has a small performance cost but it solves my problems and - in fact - makes Unzip act in a more concise way as it does not just "forget" about empty folders!

I did some benchmarking and calling CreateDirectory() a few times too often costs less than checking if we've got to create a folder first.

Hope this helps ;)
