### PR TITLE
Added very trivial progress indication support

### DIFF
--- a/Unzip.cs
+++ b/Unzip.cs
@@ -118,6 +118,8 @@ namespace Internals
 			0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94, 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d,
 		};
 
+		public event Action<int, int> ExtractProgress;
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Unzip" /> class.
 		/// </summary>
@@ -166,8 +168,10 @@ namespace Internals
 		/// <param name="directoryName">Name of the directory.</param>
 		public void ExtractToDirectory(string directoryName)
 		{
-			foreach (var entry in Entries)
+			for (int index = 0; index < Entries.Length; index++)
 			{
+				var entry = Entries[index];
+
 				// create target directory for the file
 				var fileName = Path.Combine(directoryName, entry.Name);
 				var dirName = Path.GetDirectoryName(fileName);
@@ -177,6 +181,11 @@ namespace Internals
 				if (!entry.IsDirectory)
 				{
 					Extract(entry.Name, fileName);
+				}
+				
+				if (ExtractProgress != null)
+				{
+				    ExtractProgress(index + 1, Entries.Length);
 				}
 			}
 		}
@@ -307,7 +316,7 @@ namespace Internals
 		/// <summary>
 		/// Gets zip file entries.
 		/// </summary>
-		public IEnumerable<Entry> Entries
+		public Entry[] Entries
 		{
 			get
 			{


### PR DESCRIPTION
Hi,

This one I also added to my own copy of the file, but I want to contribute it back to you so I can do NuGet updates. :smile: It should be a no-brainer really; you get access to an event handler which will get called by Unzip.cs as the unzipping proceeds.

(As a slight side note, the crc32 code you added could take some cleanups I think. Not criticizing it as so, just seeing "room for improvement". I am not volunteering at the moment for lack of time, but it feels like the current implementation strongly breaks the [separation of concerns](http://en.wikipedia.org/wiki/Separation_of_concerns) design principle, where all the actual code for calculating the CRC32 is inline in the actual unzipping code. It would be better to try to keep that part in a separate method, or even a sub-class of its own wouldn't be improper in this case.)

Best regards,
Per
